### PR TITLE
Fix Exfat corruption when you use the timestamp functions

### DIFF
--- a/src/ExFatLib/ExFatFileWrite.cpp
+++ b/src/ExFatLib/ExFatFileWrite.cpp
@@ -493,7 +493,7 @@ bool ExFatFile::timestamp(uint8_t flags, uint16_t year, uint8_t month,
   time = FS_TIME(hour, minute, second);
   ms10 = second & 1 ? 100 : 0;
 
-  for (uint8_t is = 0;; is++) {
+  for (uint8_t is = 0; is <= m_setCount ; is++) {
     cache = dirCache(is, FsCache::CACHE_FOR_READ);
     if (!cache) {
       DBG_FAIL_MACRO;


### PR DESCRIPTION
As mentioned in email and forum postings:  we were corrupting exfat partitions.  Turned out bug in the time stamp code.
A one line fix appears to resolve it. 

Described in the issue:
https://github.com/greiman/SdFat/issues/340
And I tried His solution

