### PR TITLE
Gpt disks

### DIFF
--- a/src/ExFatLib/ExFatFileWrite.cpp
+++ b/src/ExFatLib/ExFatFileWrite.cpp
@@ -493,7 +493,7 @@ bool ExFatFile::timestamp(uint8_t flags, uint16_t year, uint8_t month,
   time = FS_TIME(hour, minute, second);
   ms10 = second & 1 ? 100 : 0;
 
-  for (uint8_t is = 0;; is++) {
+  for (uint8_t is = 0; is <= m_setCount ; is++) {
     cache = dirCache(is, FsCache::CACHE_FOR_READ);
     if (!cache) {
       DBG_FAIL_MACRO;

--- a/src/ExFatLib/ExFatPartition.cpp
+++ b/src/ExFatLib/ExFatPartition.cpp
@@ -28,6 +28,7 @@
 #include "../common/FsStructs.h"
 
 #define SUPPORT_GPT 1
+#define SUPPORT_EXTENDED 1
 //------------------------------------------------------------------------------
 // return 0 if error, 1 if no space, else start cluster.
 uint32_t ExFatPartition::bitmapFind(uint32_t cluster, uint32_t count) {
@@ -267,21 +268,25 @@ uint32_t ExFatPartition::freeClusterCount() {
 }
 //------------------------------------------------------------------------------
 bool ExFatPartition::init(BlockDevice* dev, uint8_t part) {
+  Serial.printf("ExFatPartition::init(%x, %u)\n", (uint32_t)dev, part); Serial.flush();
   uint32_t volStart = 0;
   uint8_t* cache;
   pbs_t* pbs;
   BpbExFat_t* bpb;
   MbrSector_t* mbr;
   MbrPart_t* mp;
+  #if SUPPORT_GPT 
   GPTPartitionHeader_t* gptph;
   GPTPartitionEntrySector_t *gptes;
   GPTPartitionEntryItem_t *gptei;
-
+  #endif
 
   m_fatType = 0;
   m_blockDev = dev;
   cacheInit(m_blockDev);
   cache = dataCacheGet(0, FsCache::CACHE_FOR_READ);
+  if (!cache) { DBG_FAIL_MACRO; goto fail; }
+  Serial.println("    After datacacheGet");
   #if SUPPORT_GPT 
   // Lets see if we are on a GPT disk or not look for GPT guard
   mbr = reinterpret_cast<MbrSector_t*>(cache);
@@ -318,22 +323,77 @@ bool ExFatPartition::init(BlockDevice* dev, uint8_t part) {
   } else
   #endif
   {
-    // Simple MBR handling...
-    if (part > 4 || !cache) {
-      DBG_FAIL_MACRO;
-      goto fail;
-    }
+    // MBR handling...
     if (part >= 1) {
       mbr = reinterpret_cast<MbrSector_t*>(cache);
+
+      #if SUPPORT_EXTENDED
+      // Extended support we need to walk through the partitions to see if there is an extended partition
+      // that we need to walk into. 
+      part--; // zero base it.
+      // short cut:
+      bool part_index_item_valid = false;
+      if (part < 4) {
+        // try quick way through
+        mp = &mbr->part[part];
+        if (((mp->boot == 0) || (mp->boot == 0X80)) && (mp->type != 0) && (mp->type != 0xf)) {
+          part_index_item_valid = true;
+          volStart = getLe32(mp->relativeSectors);
+          Serial.println("    >> Found direct"); Serial.flush();
+        }
+      }  
+      if (! part_index_item_valid) {
+        Serial.println("    >> Need to walk list look for Extended type");
+        uint8_t index_part;
+        for (index_part = 0; index_part < 4; index_part++) {
+          mp = &mbr->part[index_part];
+          if ((mp->boot != 0 && mp->boot != 0X80) || mp->type == 0 || index_part > part) { DBG_FAIL_MACRO; goto fail; }
+          if (mp->type == 0xf) break;
+        }
+
+        if (index_part == 4) { DBG_FAIL_MACRO; goto fail; } // no extended partition found. 
+        Serial.printf("    Found Extended: %u\n", index_part);
+
+        // Our partition if it exists is in extended partition. 
+        uint32_t next_mbr = getLe32(mp->relativeSectors);
+        for(;;) {
+          Serial.printf("    Index: %u Read Block: %u\n", index_part, next_mbr);
+          cache = dataCacheGet(next_mbr, FsCache::CACHE_FOR_READ);
+          if (!cache) { Serial.println("    Failed read");DBG_FAIL_MACRO; goto fail; }
+          Serial.println("    After Read Block"); Serial.flush();
+          mbr = reinterpret_cast<MbrSector_t*>(cache);
+          if (index_part == part) break; // should be at that entry
+          // else we need to see if it points to others...
+          mp = &mbr->part[1];
+          volStart = getLe32(mp->relativeSectors);
+          Serial.printf("    Check for next: type: %u start:%u\n ", mp->type, volStart);
+          if ((mp->type == 5) && volStart) {
+            next_mbr = next_mbr + volStart;
+            index_part++; 
+          } else { DBG_FAIL_MACRO; goto fail; }
+        }
+        // If we are here than we shoul hopefully be at start of segment...
+        mp = &mbr->part[0];
+        volStart = getLe32(mp->relativeSectors) + next_mbr;
+        Serial.printf("    Exit loop %u\n", volStart);
+      }
+      #else
+      // Simple 
+      if (part > 4) {
+        DBG_FAIL_MACRO;
+        goto fail;
+      }
       mp = &mbr->part[part - 1];
       if ((mp->boot != 0 && mp->boot != 0X80) || mp->type == 0) {
         DBG_FAIL_MACRO;
         goto fail;
       }
       volStart = getLe32(mp->relativeSectors);
+      #endif
     }
   }
 
+  Serial.printf("    Read in Data sector: %u\n", (uint32_t)volStart);
   cache = dataCacheGet(volStart, FsCache::CACHE_FOR_READ);
   if (!cache) {
     DBG_FAIL_MACRO;
@@ -361,9 +421,11 @@ bool ExFatPartition::init(BlockDevice* dev, uint8_t part) {
   m_bitmapStart = 0;
   bitmapFind(0, 1);
   m_fatType = FAT_TYPE_EXFAT;
+  Serial.println("    Valid ExFat");
   return true;
 
  fail:
+  Serial.println("    Fail");
   return false;
 }
 //------------------------------------------------------------------------------

--- a/src/ExFatLib/ExFatPartition.cpp
+++ b/src/ExFatLib/ExFatPartition.cpp
@@ -26,9 +26,8 @@
 #include "../common/DebugMacros.h"
 #include "ExFatVolume.h"
 #include "../common/FsStructs.h"
+#include "../common/FsGetPartitionInfo.h"
 
-#define SUPPORT_GPT 1
-#define SUPPORT_EXTENDED 1
 //------------------------------------------------------------------------------
 // return 0 if error, 1 if no space, else start cluster.
 uint32_t ExFatPartition::bitmapFind(uint32_t cluster, uint32_t count) {
@@ -268,132 +267,44 @@ uint32_t ExFatPartition::freeClusterCount() {
 }
 //------------------------------------------------------------------------------
 bool ExFatPartition::init(BlockDevice* dev, uint8_t part) {
-  Serial.printf("ExFatPartition::init(%x, %u)\n", (uint32_t)dev, part); Serial.flush();
   uint32_t volStart = 0;
   uint8_t* cache;
   pbs_t* pbs;
-  BpbExFat_t* bpb;
+  #if SUPPORT_GPT_AND_EXTENDED_PATITIONS 
+  uint32_t firstLBA;
+  #else
   MbrSector_t* mbr;
-  MbrPart_t* mp;
-  #if SUPPORT_GPT 
-  GPTPartitionHeader_t* gptph;
-  GPTPartitionEntrySector_t *gptes;
-  GPTPartitionEntryItem_t *gptei;
   #endif
+  BpbExFat_t* bpb;
 
   m_fatType = 0;
   m_blockDev = dev;
   cacheInit(m_blockDev);
-  cache = dataCacheGet(0, FsCache::CACHE_FOR_READ);
-  if (!cache) { DBG_FAIL_MACRO; goto fail; }
-  Serial.println("    After datacacheGet");
-  #if SUPPORT_GPT 
-  // Lets see if we are on a GPT disk or not look for GPT guard
-  mbr = reinterpret_cast<MbrSector_t*>(cache);
-  mp = &mbr->part[0];
-  if (mp->type == 0xee) {
-    cache = dataCacheGet(1, FsCache::CACHE_FOR_READ);
-    gptph = reinterpret_cast<GPTPartitionHeader_t*>(cache);
 
-    // Lets do a little validation of this data.
-    if (!cache || (memcmp(gptph->signature, F("EFI PART"), 8) != 0)) {
-      DBG_FAIL_MACRO;
-      goto fail;
-    }
-    if (part > getLe32(gptph->numberPartitions)) {
-      DBG_FAIL_MACRO;
-      goto fail;
-    }
-    part--; // Make it 0 based... 4 entries per sector...
-    cache = dataCacheGet(2 + (part >> 2), FsCache::CACHE_FOR_READ);
-    if (!cache) {
-      DBG_FAIL_MACRO;
-      goto fail;      
-    }
-    gptes = reinterpret_cast<GPTPartitionEntrySector_t*>(cache);
-    gptei = &gptes->items[part & 0x3];
 
-    // Now make sure it is q guid we can handle.  For now only Microsoft Basic Data...
-    static const uint8_t microsoft_basic_data_partition_guid[16] PROGMEM = {0xA2, 0xA0, 0xD0, 0xEB, 0xE5, 0xB9, 0x33, 0x44, 0x87, 0xC0, 0x68, 0xB6, 0xB7, 0x26, 0x99, 0xC7};
-    if (memcmp((uint8_t *)gptei->partitionTypeGUID, microsoft_basic_data_partition_guid, 16) != 0) {
-      DBG_FAIL_MACRO;
-      goto fail;      
-    }
-    volStart = getLe64(gptei->firstLBA);
-  } else
-  #endif
-  {
-    // MBR handling...
-    if (part >= 1) {
-      mbr = reinterpret_cast<MbrSector_t*>(cache);
-
-      #if SUPPORT_EXTENDED
-      // Extended support we need to walk through the partitions to see if there is an extended partition
-      // that we need to walk into. 
-      part--; // zero base it.
-      // short cut:
-      bool part_index_item_valid = false;
-      if (part < 4) {
-        // try quick way through
-        mp = &mbr->part[part];
-        if (((mp->boot == 0) || (mp->boot == 0X80)) && (mp->type != 0) && (mp->type != 0xf)) {
-          part_index_item_valid = true;
-          volStart = getLe32(mp->relativeSectors);
-          Serial.println("    >> Found direct"); Serial.flush();
-        }
-      }  
-      if (! part_index_item_valid) {
-        Serial.println("    >> Need to walk list look for Extended type");
-        uint8_t index_part;
-        for (index_part = 0; index_part < 4; index_part++) {
-          mp = &mbr->part[index_part];
-          if ((mp->boot != 0 && mp->boot != 0X80) || mp->type == 0 || index_part > part) { DBG_FAIL_MACRO; goto fail; }
-          if (mp->type == 0xf) break;
-        }
-
-        if (index_part == 4) { DBG_FAIL_MACRO; goto fail; } // no extended partition found. 
-        Serial.printf("    Found Extended: %u\n", index_part);
-
-        // Our partition if it exists is in extended partition. 
-        uint32_t next_mbr = getLe32(mp->relativeSectors);
-        for(;;) {
-          Serial.printf("    Index: %u Read Block: %u\n", index_part, next_mbr);
-          cache = dataCacheGet(next_mbr, FsCache::CACHE_FOR_READ);
-          if (!cache) { Serial.println("    Failed read");DBG_FAIL_MACRO; goto fail; }
-          Serial.println("    After Read Block"); Serial.flush();
-          mbr = reinterpret_cast<MbrSector_t*>(cache);
-          if (index_part == part) break; // should be at that entry
-          // else we need to see if it points to others...
-          mp = &mbr->part[1];
-          volStart = getLe32(mp->relativeSectors);
-          Serial.printf("    Check for next: type: %u start:%u\n ", mp->type, volStart);
-          if ((mp->type == 5) && volStart) {
-            next_mbr = next_mbr + volStart;
-            index_part++; 
-          } else { DBG_FAIL_MACRO; goto fail; }
-        }
-        // If we are here than we shoul hopefully be at start of segment...
-        mp = &mbr->part[0];
-        volStart = getLe32(mp->relativeSectors) + next_mbr;
-        Serial.printf("    Exit loop %u\n", volStart);
-      }
-      #else
-      // Simple 
-      if (part > 4) {
-        DBG_FAIL_MACRO;
-        goto fail;
-      }
-      mp = &mbr->part[part - 1];
-      if ((mp->boot != 0 && mp->boot != 0X80) || mp->type == 0) {
-        DBG_FAIL_MACRO;
-        goto fail;
-      }
-      volStart = getLe32(mp->relativeSectors);
-      #endif
-    }
+  #if SUPPORT_GPT_AND_EXTENDED_PATITIONS 
+  cache = cacheClear(); // get buffer to use. 
+  FsGetPartitionInfo::voltype_t vt = FsGetPartitionInfo::getPartitionInfo(m_blockDev, part,cache, &firstLBA);
+  if ((vt == FsGetPartitionInfo::INVALID_VOL) || (vt == FsGetPartitionInfo::OTHER_VOL)) {
+    DBG_FAIL_MACRO;
+    goto fail;    
   }
+  volStart = firstLBA;
 
-  Serial.printf("    Read in Data sector: %u\n", (uint32_t)volStart);
+  #else
+  // Simple 
+  if (part > 4) {
+    DBG_FAIL_MACRO;
+    goto fail;
+  }
+  mp = &mbr->part[part - 1];
+  if ((mp->boot != 0 && mp->boot != 0X80) || mp->type == 0) {
+    DBG_FAIL_MACRO;
+    goto fail;
+  }
+  volStart = getLe32(mp->relativeSectors);
+  #endif
+
   cache = dataCacheGet(volStart, FsCache::CACHE_FOR_READ);
   if (!cache) {
     DBG_FAIL_MACRO;
@@ -421,11 +332,9 @@ bool ExFatPartition::init(BlockDevice* dev, uint8_t part) {
   m_bitmapStart = 0;
   bitmapFind(0, 1);
   m_fatType = FAT_TYPE_EXFAT;
-  Serial.println("    Valid ExFat");
   return true;
 
  fail:
-  Serial.println("    Fail");
   return false;
 }
 //------------------------------------------------------------------------------

--- a/src/FatLib/FatPartition.cpp
+++ b/src/FatLib/FatPartition.cpp
@@ -28,6 +28,7 @@
 #include "../common/FsStructs.h"
 #include "FatPartition.h"
 #define SUPPORT_GPT 1
+#define SUPPORT_EXTENDED 1
 
 //------------------------------------------------------------------------------
 bool FatPartition::allocateCluster(uint32_t current, uint32_t* next) {
@@ -429,15 +430,18 @@ bool FatPartition::init(BlockDevice* dev, uint8_t part) {
   m_fatType = 0;
   m_allocSearchStart = 1;
   m_cache.init(dev);
+  #if SUPPORT_GPT 
   GPTPartitionHeader_t* gptph;
   GPTPartitionEntrySector_t *gptes;
   GPTPartitionEntryItem_t *gptei;
+  #endif
 #if USE_SEPARATE_FAT_CACHE
   m_fatCache.init(dev);
 #endif  // USE_SEPARATE_FAT_CACHE
 
   mbr = reinterpret_cast<MbrSector_t*>
         (cacheFetchData(0, FsCache::CACHE_FOR_READ));
+  if (!mbr) { DBG_FAIL_MACRO; goto fail; }
 
 #if SUPPORT_GPT 
   // Lets see if we are on a GPT disk or not look for GPT guard
@@ -475,10 +479,59 @@ bool FatPartition::init(BlockDevice* dev, uint8_t part) {
   } else
   #endif
   {
-
     // if part == 0 assume super floppy with FAT boot sector in sector zero
     // if part > 0 assume mbr volume with partition table
     if (part) {
+      #if SUPPORT_EXTENDED
+      // Extended support we need to walk through the partitions to see if there is an extended partition
+      // that we need to walk into. 
+      part--; // zero base it.
+      // short cut:
+      bool part_index_item_valid = false;
+      if (part < 4) {
+        // try quick way through
+        mp = &mbr->part[part];
+        if (((mp->boot == 0) || (mp->boot == 0X80)) && (mp->type != 0) && (mp->type != 0xf)) {
+          part_index_item_valid = true;
+          volumeStartSector = getLe32(mp->relativeSectors);
+          Serial.println("    >> Found direct"); Serial.flush();
+        }
+      }  
+      if (! part_index_item_valid) {
+        Serial.println("    >> Need to walk list look for Extended type");
+        uint8_t index_part;
+        for (index_part = 0; index_part < 4; index_part++) {
+          mp = &mbr->part[index_part];
+          if ((mp->boot != 0 && mp->boot != 0X80) || mp->type == 0 || index_part > part) { DBG_FAIL_MACRO; goto fail; }
+          if (mp->type == 0xf) break;
+        }
+
+        if (index_part == 4) { DBG_FAIL_MACRO; goto fail; } // no extended partition found. 
+        Serial.printf("    Found Extended: %u\n", index_part);
+
+        // Our partition if it exists is in extended partition. 
+        uint32_t next_mbr = getLe32(mp->relativeSectors);
+        for(;;) {
+          Serial.printf("    Index: %u Read Block: %u\n", index_part, next_mbr);
+          mbr = reinterpret_cast<MbrSector_t*>
+                (cacheFetchData(next_mbr, FsCache::CACHE_FOR_READ));
+          if (!mbr) { DBG_FAIL_MACRO; goto fail; }
+          if (index_part == part) break; // should be at that entry
+          // else we need to see if it points to others...
+          mp = &mbr->part[1];
+          volumeStartSector = getLe32(mp->relativeSectors);
+          Serial.printf("    Check for next: type: %u start:%u\n ", mp->type, volumeStartSector);
+          if ((mp->type == 5) && volumeStartSector) {
+            next_mbr = next_mbr + volumeStartSector;
+            index_part++; 
+          } else { DBG_FAIL_MACRO; goto fail; }
+        }
+        // If we are here than we shoul hopefully be at start of segment...
+        mp = &mbr->part[0];
+        volumeStartSector = getLe32(mp->relativeSectors) + next_mbr;
+        Serial.printf("    Exit loop %u\n", volumeStartSector);
+      }
+      #else
       if (part > 4) {
         DBG_FAIL_MACRO;
         goto fail;
@@ -490,6 +543,7 @@ bool FatPartition::init(BlockDevice* dev, uint8_t part) {
         goto fail;
       }
       volumeStartSector = getLe32(mp->relativeSectors);
+      #endif
     }
   }
   pbs = reinterpret_cast<pbs_t*>

--- a/src/FatLib/FatPartition.cpp
+++ b/src/FatLib/FatPartition.cpp
@@ -26,9 +26,8 @@
 #define DBG_FILE "FatPartition.cpp"
 #include "../common/DebugMacros.h"
 #include "../common/FsStructs.h"
+#include "../common/FsGetPartitionInfo.h"
 #include "FatPartition.h"
-#define SUPPORT_GPT 1
-#define SUPPORT_EXTENDED 1
 
 //------------------------------------------------------------------------------
 bool FatPartition::allocateCluster(uint32_t current, uint32_t* next) {
@@ -424,128 +423,42 @@ bool FatPartition::init(BlockDevice* dev, uint8_t part) {
   m_blockDev = dev;
   pbs_t* pbs;
   BpbFat32_t* bpb;
+  #if SUPPORT_GPT_AND_EXTENDED_PATITIONS 
+  uint32_t firstLBA;
+  #else
   MbrSector_t* mbr;
   MbrPart_t* mp;
+  #endif
+
   uint8_t tmp;
   m_fatType = 0;
   m_allocSearchStart = 1;
   m_cache.init(dev);
-  #if SUPPORT_GPT 
-  GPTPartitionHeader_t* gptph;
-  GPTPartitionEntrySector_t *gptes;
-  GPTPartitionEntryItem_t *gptei;
-  #endif
 #if USE_SEPARATE_FAT_CACHE
   m_fatCache.init(dev);
 #endif  // USE_SEPARATE_FAT_CACHE
 
-  mbr = reinterpret_cast<MbrSector_t*>
-        (cacheFetchData(0, FsCache::CACHE_FOR_READ));
-  if (!mbr) { DBG_FAIL_MACRO; goto fail; }
-
-#if SUPPORT_GPT 
-  // Lets see if we are on a GPT disk or not look for GPT guard
-  mp = &mbr->part[0];
-  if (mp->type == 0xee) {
-    gptph = reinterpret_cast<GPTPartitionHeader_t*>(cacheFetchData(1, FsCache::CACHE_FOR_READ));
-
-    // Lets do a little validation of this data.
-    if (!gptph || (memcmp(gptph->signature, F("EFI PART"), 8) != 0)) {
-      DBG_FAIL_MACRO;
-      goto fail;
-    }
-    uint32_t numberPartitions = getLe32(gptph->numberPartitions);
-    if (part > numberPartitions) {
-      DBG_FAIL_MACRO;
-      goto fail;
-    }
-    part--; // Make it 0 based... 4 entries per sector...
-    gptes = reinterpret_cast<GPTPartitionEntrySector_t*>
-      (cacheFetchData(2 + (part >> 2), FsCache::CACHE_FOR_READ));
-    if (!gptes) {
-      DBG_FAIL_MACRO;
-      goto fail;      
-    }
-    gptei = &gptes->items[part & 0x3];
-
-    // Now make sure it is q guid we can handle.  For now only Microsoft Basic Data...
-    static const uint8_t microsoft_basic_data_partition_guid[16] PROGMEM = {0xA2, 0xA0, 0xD0, 0xEB, 0xE5, 0xB9, 0x33, 0x44, 0x87, 0xC0, 0x68, 0xB6, 0xB7, 0x26, 0x99, 0xC7};
-    if (memcmp((uint8_t *)gptei->partitionTypeGUID, microsoft_basic_data_partition_guid, 16) != 0) {
-      DBG_FAIL_MACRO;
-      goto fail;      
-    }
-    volumeStartSector = getLe64(gptei->firstLBA);
-
-  } else
-  #endif
-  {
-    // if part == 0 assume super floppy with FAT boot sector in sector zero
-    // if part > 0 assume mbr volume with partition table
-    if (part) {
-      #if SUPPORT_EXTENDED
-      // Extended support we need to walk through the partitions to see if there is an extended partition
-      // that we need to walk into. 
-      part--; // zero base it.
-      // short cut:
-      bool part_index_item_valid = false;
-      if (part < 4) {
-        // try quick way through
-        mp = &mbr->part[part];
-        if (((mp->boot == 0) || (mp->boot == 0X80)) && (mp->type != 0) && (mp->type != 0xf)) {
-          part_index_item_valid = true;
-          volumeStartSector = getLe32(mp->relativeSectors);
-          Serial.println("    >> Found direct"); Serial.flush();
-        }
-      }  
-      if (! part_index_item_valid) {
-        Serial.println("    >> Need to walk list look for Extended type");
-        uint8_t index_part;
-        for (index_part = 0; index_part < 4; index_part++) {
-          mp = &mbr->part[index_part];
-          if ((mp->boot != 0 && mp->boot != 0X80) || mp->type == 0 || index_part > part) { DBG_FAIL_MACRO; goto fail; }
-          if (mp->type == 0xf) break;
-        }
-
-        if (index_part == 4) { DBG_FAIL_MACRO; goto fail; } // no extended partition found. 
-        Serial.printf("    Found Extended: %u\n", index_part);
-
-        // Our partition if it exists is in extended partition. 
-        uint32_t next_mbr = getLe32(mp->relativeSectors);
-        for(;;) {
-          Serial.printf("    Index: %u Read Block: %u\n", index_part, next_mbr);
-          mbr = reinterpret_cast<MbrSector_t*>
-                (cacheFetchData(next_mbr, FsCache::CACHE_FOR_READ));
-          if (!mbr) { DBG_FAIL_MACRO; goto fail; }
-          if (index_part == part) break; // should be at that entry
-          // else we need to see if it points to others...
-          mp = &mbr->part[1];
-          volumeStartSector = getLe32(mp->relativeSectors);
-          Serial.printf("    Check for next: type: %u start:%u\n ", mp->type, volumeStartSector);
-          if ((mp->type == 5) && volumeStartSector) {
-            next_mbr = next_mbr + volumeStartSector;
-            index_part++; 
-          } else { DBG_FAIL_MACRO; goto fail; }
-        }
-        // If we are here than we shoul hopefully be at start of segment...
-        mp = &mbr->part[0];
-        volumeStartSector = getLe32(mp->relativeSectors) + next_mbr;
-        Serial.printf("    Exit loop %u\n", volumeStartSector);
-      }
-      #else
-      if (part > 4) {
-        DBG_FAIL_MACRO;
-        goto fail;
-      }
-      mp = mbr->part + part - 1;
-
-      if (!mbr || mp->type == 0 || (mp->boot != 0 && mp->boot != 0X80)) {
-        DBG_FAIL_MACRO;
-        goto fail;
-      }
-      volumeStartSector = getLe32(mp->relativeSectors);
-      #endif
-    }
+  #if SUPPORT_GPT_AND_EXTENDED_PATITIONS 
+  FsGetPartitionInfo::voltype_t vt = FsGetPartitionInfo::getPartitionInfo(m_blockDev, part, cacheClear(), &firstLBA);
+  if ((vt == FsGetPartitionInfo::INVALID_VOL) || (vt == FsGetPartitionInfo::OTHER_VOL)) {
+    DBG_FAIL_MACRO;
+    goto fail;    
   }
+  volumeStartSector = firstLBA;
+  #else
+  if (part > 4) {
+    DBG_FAIL_MACRO;
+    goto fail;
+  }
+  mp = mbr->part + part - 1;
+
+  if (!mbr || mp->type == 0 || (mp->boot != 0 && mp->boot != 0X80)) {
+    DBG_FAIL_MACRO;
+    goto fail;
+  }
+  volumeStartSector = getLe32(mp->relativeSectors);
+  #endif
+
   pbs = reinterpret_cast<pbs_t*>
         (cacheFetchData(volumeStartSector, FsCache::CACHE_FOR_READ));
   bpb = reinterpret_cast<BpbFat32_t*>(pbs->bpb);

--- a/src/SdFatConfig.h
+++ b/src/SdFatConfig.h
@@ -394,6 +394,21 @@ typedef uint8_t SdCsPin_t;
 #else  // __arm__
 #define USE_EXFAT_BITMAP_CACHE 0
 #endif  // __arm__
+
+//------------------------------------------------------------------------------
+/**
+ * Set SUPPORT_GPT_AND_EXTENDED_PATITIONS  nonzero to support partitions
+ * on Extended MBR extended partitions and some support for GPT configured
+ * drives.
+ */
+#ifndef SUPPORT_GPT_AND_EXTENDED_PATITIONS
+#ifdef __arm__
+#define SUPPORT_GPT_AND_EXTENDED_PATITIONS 1
+#else  // __arm__
+#define SUPPORT_GPT_AND_EXTENDED_PATITIONS 0
+#endif  // __arm__
+#endif // SUPPORT_GPT_AND_EXTENDED_PATITIONS
+  
 //------------------------------------------------------------------------------
 /**
  * Set USE_MULTI_SECTOR_IO nonzero to use multi-sector SD read/write.

--- a/src/common/FsGetPartitionInfo.cpp
+++ b/src/common/FsGetPartitionInfo.cpp
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2011-2020 Bill Greiman
+ * This file is part of the SdFat library for SD memory cards.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+#include "FsGetPartitionInfo.h"
+namespace FsGetPartitionInfo {
+  static const uint8_t mbdpGuid[16] PROGMEM = {0xA2, 0xA0, 0xD0, 0xEB, 0xE5, 0xB9, 0x33, 0x44, 0x87, 0xC0, 0x68, 0xB6, 0xB7, 0x26, 0x99, 0xC7};
+
+  voltype_t getPartitionInfo(BlockDeviceInterface *blockDev, uint8_t part, uint8_t *secBuf,
+      uint32_t *pfirstLBA, uint32_t *psectorCount, uint32_t *pmbrLBA, uint8_t *pmbrPart) {
+
+    //Serial.printf("PFsLib::getPartitionInfo(%x, %u)\n", (uint32_t)blockDev, part);
+    uint32_t firstLBA;
+    uint32_t sectorCount;
+    MbrSector_t *mbr;
+    MbrPart_t *mp;
+
+    if (!part || !pfirstLBA) return INVALID_VOL; // won't handle this here.
+    part--; // zero base it.
+
+    if (!blockDev->readSector(0, secBuf)) return INVALID_VOL;
+    mbr = reinterpret_cast<MbrSector_t*>(secBuf);
+
+    // First check for GPT vs MBR
+    mp = &mbr->part[0];
+    if (mp->type == 0xee) {
+      // This is a GPT initialized Disk assume validation done earlier.
+      if (!blockDev->readSector(1, secBuf)) return INVALID_VOL; 
+      GPTPartitionHeader_t* gptph = reinterpret_cast<GPTPartitionHeader_t*>(secBuf);
+      // Lets do a little validation of this data.
+      if (!gptph || (memcmp(gptph->signature, F("EFI PART"), 8) != 0))  return INVALID_VOL;
+      uint32_t numberPartitions = getLe32(gptph->numberPartitions);
+      if (part > numberPartitions)  return INVALID_VOL;
+
+      // We will overload the mbr part to give clue where GPT data is stored for this volume
+      uint32_t mbrLBA = 2 + (part >> 2);
+      uint8_t mbrPart = part & 0x3;
+      if (pmbrLBA) *pmbrLBA = mbrLBA;
+      if (pmbrPart) *pmbrPart =mbrPart;
+      if (!blockDev->readSector(mbrLBA, secBuf)) return INVALID_VOL; 
+      GPTPartitionEntrySector_t *gptes = reinterpret_cast<GPTPartitionEntrySector_t*>(secBuf);
+      GPTPartitionEntryItem_t *gptei = &gptes->items[mbrPart];
+
+      // Mow extract the data...
+      firstLBA = getLe64(gptei->firstLBA);
+      sectorCount = 1 + getLe64(gptei->lastLBA) - getLe64(gptei->firstLBA);
+      if ((firstLBA == 0) && (sectorCount == 1)) return INVALID_VOL;
+      
+      *pfirstLBA = firstLBA;
+      if (psectorCount) *psectorCount = sectorCount;
+
+      if (memcmp((uint8_t *)gptei->partitionTypeGUID, mbdpGuid, 16) != 0) return OTHER_VOL;
+      return GPT_VOL; 
+    }
+    // So we are now looking a MBR type setups. 
+    // Extended support we need to walk through the partitions to see if there is an extended partition
+    // that we need to walk into. 
+    // short cut:
+    if (part < 4) {
+      // try quick way through
+      mp = &mbr->part[part];
+      if (((mp->boot == 0) || (mp->boot == 0X80)) && (mp->type != 0) && (mp->type != 0xf)) {
+        *pfirstLBA = getLe32(mp->relativeSectors);
+        if (psectorCount) *psectorCount = getLe32(mp->totalSectors);
+        if (pmbrLBA) *pmbrLBA = 0;
+        if (pmbrPart) *pmbrPart = part; // zero based. 
+        return MBR_VOL;
+      }
+    }  
+
+    // So must be extended or invalid.
+    uint8_t index_part;
+    for (index_part = 0; index_part < 4; index_part++) {
+      mp = &mbr->part[index_part];
+      if ((mp->boot != 0 && mp->boot != 0X80) || mp->type == 0 || index_part > part) return INVALID_VOL;
+      if (mp->type == 0xf) break;
+    }
+
+    if (index_part == 4) return INVALID_VOL; // no extended partition found. 
+
+    // Our partition if it exists is in extended partition. 
+    uint32_t next_mbr = getLe32(mp->relativeSectors);
+    for(;;) {
+      if (!blockDev->readSector(next_mbr, secBuf)) return INVALID_VOL;
+      mbr = reinterpret_cast<MbrSector_t*>(secBuf);
+
+      if (index_part == part) break; // should be at that entry
+      // else we need to see if it points to others...
+      mp = &mbr->part[1];
+      uint32_t  relSec = getLe32(mp->relativeSectors);
+      //Serial.printf("    Check for next: type: %u start:%u\n ", mp->type, volumeStartSector);
+      if ((mp->type == 5) && relSec) {
+        next_mbr = next_mbr + relSec;
+        index_part++; 
+      } else return INVALID_VOL;
+    }
+   
+    // If we are here than we should hopefully be at start of segment...
+    mp = &mbr->part[0];
+    *pfirstLBA = getLe32(mp->relativeSectors) + next_mbr;
+    if (psectorCount) *psectorCount = getLe32(mp->totalSectors);
+    if (pmbrLBA) *pmbrLBA = next_mbr;
+    if (pmbrPart) *pmbrPart = 0; // zero based. 
+    return EXT_VOL;
+  }
+
+}  // namespace FsUtf
+

--- a/src/common/FsGetPartitionInfo.h
+++ b/src/common/FsGetPartitionInfo.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2011-2020 Bill Greiman
+ * This file is part of the SdFat library for SD memory cards.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+#ifndef FsGetPartitionInfo_h
+#define FsGetPartitionInfo_h
+/**
+* \file
+* \brief Unicode Transformation Format functions.
+*/
+#include <stdint.h>
+#include <stddef.h>
+#include "FsStructs.h"
+#include "BlockDeviceInterface.h"
+
+namespace FsGetPartitionInfo {
+
+typedef enum {INVALID_VOL=0, MBR_VOL, EXT_VOL, GPT_VOL, OTHER_VOL} voltype_t; // what type of volume did the mapping return
+voltype_t getPartitionInfo(BlockDeviceInterface *blockDev, uint8_t part, uint8_t *secBuf,
+      uint32_t *pfirstLBA, uint32_t *psectorCount=nullptr, uint32_t *pmbrLBA=nullptr, uint8_t *pmbrPart=nullptr);
+
+}  // namespace FsGetPartitionInfo
+#endif  // FsGetPartitionInfo_h

--- a/src/common/FsStructs.h
+++ b/src/common/FsStructs.h
@@ -389,4 +389,43 @@ typedef struct {
   uint8_t  mustBeZero;
   uint8_t  unicode[30];
 } DirName_t;
+
+//-----------------------------------------------------------------------------
+// WIP GPT support for now just assume 16 bytes...
+typedef struct {
+  uint8_t data[16];
+} Guid_t;
+
+typedef struct {
+  uint8_t  signature[8];
+  uint8_t  revision[4];
+  uint8_t  headerSize[4];
+  uint8_t  crc32[4];
+  uint8_t  reserved[4];
+  uint8_t  currentLBA[8];
+  uint8_t  backupLBA[8];
+  uint8_t  firstLBA[8];
+  uint8_t  lastLBA[8];
+  uint8_t  diskGUID[16];
+  uint8_t  startLBAArray[8];
+  uint8_t  numberPartitions[4];
+  uint8_t  sizePartitionEntry[4];
+  uint8_t  crc32PartitionEntries[4];
+  uint8_t  unused[420]; // should be 0;
+} GPTPartitionHeader_t;
+
+typedef struct {
+  uint8_t  partitionTypeGUID[16];
+  uint8_t  uniqueGUID[16];
+  uint8_t  firstLBA[8];
+  uint8_t  lastLBA[8];
+  uint8_t  attributeFlags[8];
+  uint16_t name[36];
+} GPTPartitionEntryItem_t;
+
+typedef struct {
+  GPTPartitionEntryItem_t items[4];
+} GPTPartitionEntrySector_t;
+
+
 #endif  // FsStructs_h


### PR DESCRIPTION
@PaulStoffregen  @mjs513 - As mentioned in the email and forum posts. 

Mike and I have worked on supporting for partitions in the SDFat library.  

This is more important in the case of the MSC drives (USBHost) 

In particular: on MBR type disks, this code adds support find and use partitions in the Extended partition.  This come up on disks, for example Windows partition generation code will at times automatically create an extended partition and then generate the new partition under it. 

Also added some support now for disks using GPT  In particular detects that the MBR is setup as a GPT guard and then it will try to work with partitions built under it.  Currently it only supports looks for Fat/exFat under the Microsoft Data... GUID, but can be extended if we find others that support FAT under them. 

this code also probably has some fixes we found along the way. 

Again unclear if this is something that you wish to merge now or not.  But I know that Mike and I have been doing most of our testing using this fork/branch.

