### PR TITLE
Fix for WAV files not play on TMM SDIO

### DIFF
--- a/src/SdCard/SdioTeensy.cpp
+++ b/src/SdCard/SdioTeensy.cpp
@@ -334,7 +334,7 @@ static void gpioMux(uint8_t mode) {
 // add speed strength args?
 static void enableGPIO(bool enable) {
   const uint32_t CLOCK_MASK = IOMUXC_SW_PAD_CTL_PAD_PKE |
-#if defined(ARDUINO_TEENSY41)
+#if defined(ARDUINO_TEENSY41) || defined(ARDUINO_TEENSY_MICROMOD)
                               IOMUXC_SW_PAD_CTL_PAD_DSE(7) |
 #else  // defined(ARDUINO_TEENSY41)
                               IOMUXC_SW_PAD_CTL_PAD_DSE(4) |  ///// WHG


### PR DESCRIPTION
Paul - @KurtE
This is the fix for the issue of WAVE files not playing from the SDIO on the Teensy Micromod breakout board.  Relatively easy fix after Kurt tracked down where the problem was.  Discussion on the MTP/MSC Integration Thread.