### PR TITLE
Changed the DSE change to just IMXRT1062

### DIFF
--- a/src/SdCard/SdioTeensy.cpp
+++ b/src/SdCard/SdioTeensy.cpp
@@ -334,7 +334,7 @@ static void gpioMux(uint8_t mode) {
 // add speed strength args?
 static void enableGPIO(bool enable) {
   const uint32_t CLOCK_MASK = IOMUXC_SW_PAD_CTL_PAD_PKE |
-#if defined(ARDUINO_TEENSY41) || defined(ARDUINO_TEENSY_MICROMOD)
+#if defined(__IMXRT1062__)
                               IOMUXC_SW_PAD_CTL_PAD_DSE(7) |
 #else  // defined(ARDUINO_TEENSY41)
                               IOMUXC_SW_PAD_CTL_PAD_DSE(4) |  ///// WHG


### PR DESCRIPTION
Morning Paul
Went ahead and changed the test on the drive strength to just __IMXRT1062__ even though it seems to work on the original breakouts.  Figured better safe than sorry - should have just done this to begin with.