### PR TITLE
Support Micropython plugged into USBHost which uses Fat12

### DIFF
--- a/src/FatLib/FatPartition.cpp
+++ b/src/FatLib/FatPartition.cpp
@@ -469,6 +469,13 @@ bool FatPartition::init(BlockDevice* dev, uint8_t part) {
     DBG_FAIL_MACRO;
     goto fail;
   }
+
+  m_fatCount = bpb->fatCount;
+  // handle fat counts 1 or 2...
+  if ((m_fatCount != 1) && (m_fatCount != 2)) {
+    DBG_FAIL_MACRO;
+    goto fail;
+  }
   m_sectorsPerCluster = bpb->sectorsPerCluster;
   m_clusterSectorMask = m_sectorsPerCluster - 1;
   // determine shift that is same as multiply by m_sectorsPerCluster

--- a/src/FatLib/FatPartition.cpp
+++ b/src/FatLib/FatPartition.cpp
@@ -423,6 +423,7 @@ bool FatPartition::init(BlockDevice* dev, uint8_t part) {
   m_blockDev = dev;
   pbs_t* pbs;
   BpbFat32_t* bpb;
+  uint8_t mbrType = 0;
   #if SUPPORT_GPT_AND_EXTENDED_PATITIONS 
   uint32_t firstLBA;
   #else
@@ -439,7 +440,8 @@ bool FatPartition::init(BlockDevice* dev, uint8_t part) {
 #endif  // USE_SEPARATE_FAT_CACHE
 
   #if SUPPORT_GPT_AND_EXTENDED_PATITIONS 
-  FsGetPartitionInfo::voltype_t vt = FsGetPartitionInfo::getPartitionInfo(m_blockDev, part, cacheClear(), &firstLBA);
+  FsGetPartitionInfo::voltype_t vt = FsGetPartitionInfo::getPartitionInfo(m_blockDev, part, cacheClear(), &firstLBA, 
+        nullptr, nullptr, nullptr, &mbrType);
   if ((vt == FsGetPartitionInfo::INVALID_VOL) || (vt == FsGetPartitionInfo::OTHER_VOL)) {
     DBG_FAIL_MACRO;
     goto fail;    
@@ -508,7 +510,7 @@ bool FatPartition::init(BlockDevice* dev, uint8_t part) {
   // Indicate unknown number of free clusters.
   setFreeClusterCount(-1);
   // FAT type is determined by cluster count
-  if (clusterCount < 4085) {
+  if ((mbrType == 1) || (clusterCount < 4085)) {
     m_fatType = 12;
     if (!FAT12_SUPPORT) {
       DBG_FAIL_MACRO;

--- a/src/FatLib/FatPartition.cpp
+++ b/src/FatLib/FatPartition.cpp
@@ -463,7 +463,7 @@ bool FatPartition::init(BlockDevice* dev, uint8_t part) {
   pbs = reinterpret_cast<pbs_t*>
         (cacheFetchData(volumeStartSector, FsCache::CACHE_FOR_READ));
   bpb = reinterpret_cast<BpbFat32_t*>(pbs->bpb);
-  if (!pbs || bpb->fatCount != 2 || getLe16(bpb->bytesPerSector) != 512) {
+  if (!pbs || getLe16(bpb->bytesPerSector) != 512) {
     DBG_FAIL_MACRO;
     goto fail;
   }
@@ -488,7 +488,7 @@ bool FatPartition::init(BlockDevice* dev, uint8_t part) {
   m_rootDirEntryCount = getLe16(bpb->rootDirEntryCount);
 
   // directory start for FAT16 dataStart for FAT32
-  m_rootDirStart = m_fatStartSector + 2 * m_sectorsPerFat;
+  m_rootDirStart = m_fatStartSector + bpb->fatCount * m_sectorsPerFat;
   // data start for FAT16 and FAT32
   m_dataStartSector = m_rootDirStart +
     ((32 * m_rootDirEntryCount + m_bytesPerSector - 1)/m_bytesPerSector);

--- a/src/FatLib/FatPartition.h
+++ b/src/FatLib/FatPartition.h
@@ -194,6 +194,7 @@ class FatPartition {
   uint8_t  m_clusterSectorMask;       // Mask to extract sector of cluster.
   uint8_t  m_sectorsPerClusterShift;  // Cluster count to sector count shift.
   uint8_t  m_fatType = 0;             // Volume type (12, 16, OR 32).
+  uint8_t  m_fatCount = 2;            // How many fats mostly 2 will support 1
   uint16_t m_rootDirEntryCount;       // Number of entries in FAT16 root dir.
   uint32_t m_allocSearchStart;        // Start cluster for alloc search.
   uint32_t m_sectorsPerFat;           // FAT size in sectors
@@ -251,7 +252,7 @@ static void freeClusterCount_cb_fat32(uint32_t sector, uint8_t *buf, void *conte
 #if USE_SEPARATE_FAT_CACHE
   FsCache m_fatCache;
   cache_t* cacheFetchFat(uint32_t sector, uint8_t options) {
-    options |= FsCache::CACHE_STATUS_MIRROR_FAT;
+    if (m_fatCount == 2) options |= FsCache::CACHE_STATUS_MIRROR_FAT;
     return reinterpret_cast<cache_t*>(m_fatCache.get(sector, options));
   }
   bool cacheSync() {
@@ -259,7 +260,7 @@ static void freeClusterCount_cb_fat32(uint32_t sector, uint8_t *buf, void *conte
   }
 #else  // USE_SEPARATE_FAT_CACHE
   cache_t* cacheFetchFat(uint32_t sector, uint8_t options) {
-    options |= FsCache::CACHE_STATUS_MIRROR_FAT;
+    if (m_fatCount == 2) options |= FsCache::CACHE_STATUS_MIRROR_FAT;
     return cacheFetchData(sector, options);
   }
   bool cacheSync() {

--- a/src/SdFatConfig.h
+++ b/src/SdFatConfig.h
@@ -316,7 +316,7 @@ typedef uint8_t SdCsPin_t;
  * FAT12 has not been well tested and requires additional flash.
  */
 #ifndef FAT12_SUPPORT
-#define FAT12_SUPPORT 0
+#define FAT12_SUPPORT 1
 #endif  // FAT12_SUPPORT
 //------------------------------------------------------------------------------
 /**

--- a/src/common/FsGetPartitionInfo.cpp
+++ b/src/common/FsGetPartitionInfo.cpp
@@ -27,7 +27,7 @@ namespace FsGetPartitionInfo {
   static const uint8_t mbdpGuid[16] PROGMEM = {0xA2, 0xA0, 0xD0, 0xEB, 0xE5, 0xB9, 0x33, 0x44, 0x87, 0xC0, 0x68, 0xB6, 0xB7, 0x26, 0x99, 0xC7};
 
   voltype_t getPartitionInfo(BlockDeviceInterface *blockDev, uint8_t part, uint8_t *secBuf,
-      uint32_t *pfirstLBA, uint32_t *psectorCount, uint32_t *pmbrLBA, uint8_t *pmbrPart) {
+      uint32_t *pfirstLBA, uint32_t *psectorCount, uint32_t *pmbrLBA, uint8_t *pmbrPart, uint8_t *pmbrType) {
 
     //Serial.printf("PFsLib::getPartitionInfo(%x, %u)\n", (uint32_t)blockDev, part);
     uint32_t firstLBA;
@@ -57,6 +57,7 @@ namespace FsGetPartitionInfo {
       uint8_t mbrPart = part & 0x3;
       if (pmbrLBA) *pmbrLBA = mbrLBA;
       if (pmbrPart) *pmbrPart =mbrPart;
+      if (pmbrType) *pmbrType = 0;
       if (!blockDev->readSector(mbrLBA, secBuf)) return INVALID_VOL; 
       GPTPartitionEntrySector_t *gptes = reinterpret_cast<GPTPartitionEntrySector_t*>(secBuf);
       GPTPartitionEntryItem_t *gptei = &gptes->items[mbrPart];
@@ -84,6 +85,7 @@ namespace FsGetPartitionInfo {
         if (psectorCount) *psectorCount = getLe32(mp->totalSectors);
         if (pmbrLBA) *pmbrLBA = 0;
         if (pmbrPart) *pmbrPart = part; // zero based. 
+        if (pmbrType) *pmbrType = mp->type;
         return MBR_VOL;
       }
     }  
@@ -121,6 +123,7 @@ namespace FsGetPartitionInfo {
     if (psectorCount) *psectorCount = getLe32(mp->totalSectors);
     if (pmbrLBA) *pmbrLBA = next_mbr;
     if (pmbrPart) *pmbrPart = 0; // zero based. 
+    if (pmbrType) *pmbrType = mp->type;
     return EXT_VOL;
   }
 

--- a/src/common/FsGetPartitionInfo.h
+++ b/src/common/FsGetPartitionInfo.h
@@ -37,7 +37,8 @@ namespace FsGetPartitionInfo {
 
 typedef enum {INVALID_VOL=0, MBR_VOL, EXT_VOL, GPT_VOL, OTHER_VOL} voltype_t; // what type of volume did the mapping return
 voltype_t getPartitionInfo(BlockDeviceInterface *blockDev, uint8_t part, uint8_t *secBuf,
-      uint32_t *pfirstLBA, uint32_t *psectorCount=nullptr, uint32_t *pmbrLBA=nullptr, uint8_t *pmbrPart=nullptr);
+      uint32_t *pfirstLBA, uint32_t *psectorCount=nullptr, uint32_t *pmbrLBA=nullptr, uint8_t *pmbrPart=nullptr,
+      uint8_t *pmbrType=nullptr);
 
 }  // namespace FsGetPartitionInfo
 #endif  // FsGetPartitionInfo_h


### PR DESCRIPTION
@PaulStoffregen @mjs513, @wwatson4506,

While experimenting with plugging in a board running Micropython into the usbhost connector of t3.6 or t4.x,  I found that
we do not support the file system that is running on these boards.

Two issues: They are running Fat12, which by default any support for these drives is not included in sdfat, 
So turned on that option.

Second they created the FS with only one FAT copy.  SDFat only worked with ones with 2 FATs, so put in code to recognize it and say yes and then adjust the compute of where the next thing is after the fat and to not duplicate the write to the fat if there is only one.

There is similar slight change needed in the MSC code as well, to recognize the  drive type.  Unclear when/if the MSC integration to usbhost will occur, so I did my testing and changes using unchanged USBHost_t36 library and instead put the changes
into UsbMscFat branch decouple, which we have been using.    Will migrate that back to usbhost when appropriate. 
