### PR TITLE
FAT12 only on T3.5/6 and T4.x

### DIFF
--- a/src/FatLib/FatPartition.h
+++ b/src/FatLib/FatPartition.h
@@ -116,7 +116,7 @@ class FatPartition {
   }
   /** \return The number of File Allocation Tables. */
   uint8_t fatCount() const {
-    return 2;
+    return m_fatCount;
   }
   /** \return The logical sector number for the start of the first FAT. */
   uint32_t fatStartSector() const {

--- a/src/SdFatConfig.h
+++ b/src/SdFatConfig.h
@@ -316,7 +316,12 @@ typedef uint8_t SdCsPin_t;
  * FAT12 has not been well tested and requires additional flash.
  */
 #ifndef FAT12_SUPPORT
+#if defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__IMXRT1062__)
+// mainly defined for support of USBHost builds... But included T3.5...
 #define FAT12_SUPPORT 1
+#else
+#define FAT12_SUPPORT 0
+#endif
 #endif  // FAT12_SUPPORT
 //------------------------------------------------------------------------------
 /**


### PR DESCRIPTION
@PaulStoffregen @mjs513
Mainly to talk to CircuitPython  so only enable the Fat12 code to be included when
T3.6 and T4.x... I did still allow for T3.5 as large memory...

Also fixed the fatCount() to not return hard coded 2, but instead use the value I saved away when we looked at the header information.