### PR TITLE
Fix issue which can result in SD accesses spinning forever

### DIFF
--- a/src/SdCard/SdioTeensy.cpp
+++ b/src/SdCard/SdioTeensy.cpp
@@ -819,11 +819,9 @@ bool SdioCard::readData(uint8_t* dst) {
     SDHC_PROCTL |= SDHC_PROCTL_SABGREQ;
     interrupts();
   }
-  if (waitTimeout(isBusyFifoRead)) {
-    return sdError(SD_CARD_ERROR_READ_FIFO);
-  }
   for (uint32_t iw = 0 ; iw < 512/(4*FIFO_WML); iw++) {
-    while (0 == (SDHC_PRSSTAT & SDHC_PRSSTAT_BREN)) {
+    if (waitTimeout(isBusyFifoRead)) {
+      return sdError(SD_CARD_ERROR_READ_FIFO);
     }
     for (uint32_t i = 0; i < FIFO_WML; i++) {
       p32[i] = SDHC_DATPORT;
@@ -981,11 +979,9 @@ bool SdioCard::writeData(const uint8_t* src) {
     SDHC_PROCTL |= SDHC_PROCTL_CREQ;
   }
   SDHC_PROCTL |= SDHC_PROCTL_SABGREQ;
-  if (waitTimeout(isBusyFifoWrite)) {
-    return sdError(SD_CARD_ERROR_WRITE_FIFO);
-  }
   for (uint32_t iw = 0 ; iw < 512/(4*FIFO_WML); iw++) {
-    while (0 == (SDHC_PRSSTAT & SDHC_PRSSTAT_BWEN)) {
+    if (waitTimeout(isBusyFifoWrite)) {
+      return sdError(SD_CARD_ERROR_WRITE_FIFO);
     }
     for (uint32_t i = 0; i < FIFO_WML; i++) {
       SDHC_DATPORT = p32[i];


### PR DESCRIPTION
Posted on Bill Greiman's github here: https://github.com/greiman/SdFat/issues/398, but after some discussion he declined to implement the fix and closed the ticket. It seems worth fixing to me, even if it takes some library abuse to trigger (in my case, closing one file under interrupt while another was being read from), and even if there are other similar vulnerabilities left in the code.

Should have negligible speed implications (I've tested on a Teensy 4.1 with a fast SD card), and will make the code ever so slightly smaller.