### PR TITLE
FatPartition: return bytesPerCluster as a uint32_t to avoid overflow

### DIFF
--- a/src/FatLib/FatPartition.h
+++ b/src/FatLib/FatPartition.h
@@ -59,7 +59,7 @@ class FatPartition {
     return m_sectorsPerClusterShift + m_bytesPerSectorShift;
   }
   /** \return Number of bytes in a cluster. */
-  uint16_t bytesPerCluster() const {
+  uint32_t bytesPerCluster() const {
     return m_bytesPerSector << m_sectorsPerClusterShift;
   }
   /** \return Number of bytes per sector. */


### PR DESCRIPTION
The value calculated by FatPartition::bytesPerCluster() may overflow 16 bits if the partition has 128 sectors per cluster:
512 << 7 = 65536 = (uint16_t)0

This is unlikely (but not impossible) to occur with SD cards but can definitely happen with USB drives. It will also be a problem if the library is expanded to support sector sizes other than 512B (e.g. 4KB which is common for large USB drives).