### PR TITLE
Fix problem with yield() causing crash

### DIFF
--- a/src/SdCard/SdioTeensy.h
+++ b/src/SdCard/SdioTeensy.h
@@ -273,5 +273,9 @@
 #define IOMUXC_SW_PAD_CTL_PAD_PUS_MASK  ((0x3)<<14)
 #define IOMUXC_SW_PAD_CTL_PAD_DSE(n)    (((n)&0x7)<<3)
 #define IOMUXC_SW_PAD_CTL_PAD_DSE_MASK  ((0x7)<<3)
+
+// Needed to prevent clash with EventResponder functions 
+extern uint8_t yield_active_check_flags;
+
 #endif  // defined(__IMXRT1062__)
 #endif  // SdioTeensy_h


### PR DESCRIPTION
If an EventResponder response executed from a yield() called from within SDIOTeensy also accesses the SD card, then the resulting conflict crashes the Teensy, or at least prevents any subsequent SD interaction from working.

This fix masks EventResponder responses _only_ from within SdFat - they will execute at the next "conventional" yield().