### PR TITLE
add missing BUILTIN_SDCARD for Teensy 4.x

### DIFF
--- a/src/SdFatConfig.h
+++ b/src/SdFatConfig.h
@@ -417,6 +417,9 @@ typedef uint8_t SdCsPin_t;
 #endif  // defined(__MK64FX512__) || defined(__MK66FX1M0__)
 #if defined(__IMXRT1062__)
 #define HAS_SDIO_CLASS 1
+#ifndef BUILTIN_SDCARD
+#define BUILTIN_SDCARD 254
+#endif  // BUILTIN_SDCARD
 #endif  // defined(__IMXRT1062__)
 //------------------------------------------------------------------------------
 /**


### PR DESCRIPTION
SD.sdfs.begin(BUILTIN_SDCARD) fails on Teensy 4.1 and Micromod due to BUILTIN_SDCARD not being defined when SdFat.h is compiled.
SdFat.h is #include'd at the beginning of SD.h while BUILTIN_SDCARD is defined further down. This could be switched around, but then it still wouldn't work in sketches that `#include <SdFat.h>` directly.

This simply copies the same conditional definition that exists for Teensy 3.