### PR TITLE
Fix for FAT with cluster size > 4k

### DIFF
--- a/src/FatLib/FatFileLFN.cpp
+++ b/src/FatLib/FatFileLFN.cpp
@@ -294,6 +294,7 @@ bool FatFile::open(FatFile* dirFile, FatLfn_t* fname, oflag_t oflag) {
   uint8_t ms10;
   uint8_t nameOrd;
   uint16_t freeIndex = 0;
+  uint16_t freeTotal;
   uint16_t curIndex;
   uint16_t date;
   uint16_t time;
@@ -407,13 +408,16 @@ bool FatFile::open(FatFile* dirFile, FatLfn_t* fname, oflag_t oflag) {
     }
     freeFound++;
   }
-  while (freeFound < freeNeed) {
+  // Loop handles the case of huge filename and cluster size one.
+  freeTotal = freeFound;
+  while (freeTotal < freeNeed) {
     // Will fail if FAT16 root.
     if (!dirFile->addDirCluster()) {
       DBG_FAIL_MACRO;
       goto fail;
     }
-    freeFound += vol->dirEntriesPerCluster();
+    // 16-bit freeTotal needed for large cluster size.
+    freeTotal += vol->dirEntriesPerCluster();
   }
   if (fnameFound) {
     if (!dirFile->makeUniqueSfn(fname)) {


### PR DESCRIPTION
On **newly formatted** SD cards on a Teensy 4.1 with cluster sizes >=8k creating new files results in sporadic but reproducable failures. Specifically the FatFile::open fails (in my case on creating the 83th file).
Using Greiman's SdFat no issues occured. The issue was fixed in [v2.2.2](https://github.com/greiman/SdFat/commit/57900b21d21655c513ef7e344f55e8190e612dcb)